### PR TITLE
Repeaters

### DIFF
--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -336,8 +336,10 @@ endfunction
 
 function! SimpleSnippets#initMirror(current)
 	let l:placeholder = '\v(\$\{'. a:current . '\|)@<=.{-}(\})@='
-	call add(s:jump_stack, matchstr(getline('.'), l:placeholder))
+	let l:result = matchstr(getline('.'), l:placeholder)
+	call add(s:jump_stack, l:result)
 	exe "normal! df|f}i\<Del>\<Esc>"
+	call SimpleSnippets#initRepeater(a:current, l:result)
 endfunction
 
 function! SimpleSnippets#initShell(current)
@@ -361,6 +363,21 @@ function! SimpleSnippets#initShell(current)
 	endif
 	exe "normal! vf}c"
 	normal! "sp
+	call SimpleSnippets#initRepeater(a:current, l:result)
+endfunction
+
+function! SimpleSnippets#initRepeater(current, content)
+	let @s = a:content
+	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
+	let l:i = 0
+	while l:i < l:repeater_count
+		call cursor(s:snip_start, 1)
+		call search('\v\$'.a:current, '', s:snip_end)
+		exe "normal! vec"
+		normal! "sp
+		let l:i += 1
+	endwhile
+	call cursor(s:snip_start, 1)
 endfunction
 
 function! SimpleSnippets#jump()

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -384,8 +384,8 @@ function! SimpleSnippets#initRepeaters(current, content, count)
 		normal! mq
 		call search('\v\$'.a:current, 'ce', s:snip_end)
 		normal! mp
-		exe "normal! `qv`px"
-		normal! "sP
+		exe "normal! `qv`pc"
+		normal! "sp
 		let l:i += 1
 	endwhile
 	let @s = l:save

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -361,8 +361,10 @@ function! SimpleSnippets#initShell(current)
 	if l:result_line_count > 1
 		let s:snip_end += l:result_line_count - 1
 	endif
-	exe "normal! vf}c"
-	normal! "sp
+	exe "normal! vf}x"
+	normal! "sP
+	redraw
+	sleep 2
 	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
 	if l:repeater_count != 0
 		call SimpleSnippets#initRepeaters(a:current, l:result, l:repeater_count)
@@ -379,8 +381,10 @@ function! SimpleSnippets#initRepeaters(current, content, count)
 		normal! mq
 		call search('\v\$'.a:current, 'ce', s:snip_end)
 		normal! mp
-		exe "normal! `qv`pc"
-		normal! "sp
+		exe "normal! `qv`px"
+		normal! "sP
+	redraw
+	sleep 2
 		let l:i += 1
 	endwhile
 	call cursor(s:snip_start, 1)

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -363,8 +363,6 @@ function! SimpleSnippets#initShell(current)
 	endif
 	exe "normal! vf}x"
 	normal! "sP
-	redraw
-	sleep 2
 	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
 	if l:repeater_count != 0
 		call SimpleSnippets#initRepeaters(a:current, l:result, l:repeater_count)
@@ -383,8 +381,6 @@ function! SimpleSnippets#initRepeaters(current, content, count)
 		normal! mp
 		exe "normal! `qv`px"
 		normal! "sP
-	redraw
-	sleep 2
 		let l:i += 1
 	endwhile
 	call cursor(s:snip_start, 1)

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -119,6 +119,7 @@ function! SimpleSnippets#expandFlashSnippet(snip)
 	let l:i = 0
 	while l:i < l:len
 		if match(a:snip, s:flash_snippets[l:i][0]) == 0
+			let l:save = @s
 			let @s = s:flash_snippets[l:i][1]
 			let s:snip_line_count = len(substitute(s:flash_snippets[l:i][1], '[^\n]', '', 'g')) + 1
 			break
@@ -126,6 +127,7 @@ function! SimpleSnippets#expandFlashSnippet(snip)
 		let l:i += 1
 	endwhile
 	normal! "sp
+	let @s = l:save
 	if s:snip_line_count != 1
 		let l:indent_lines = s:snip_line_count - 1
 		silent exec 'normal! V' . l:indent_lines . 'j='
@@ -356,6 +358,7 @@ function! SimpleSnippets#initShell(current)
 	let l:result = substitute(l:result, '\s\+$', '', '')
 	let l:result = substitute(l:result, '^\s\+', '', '')
 	let l:result = substitute(l:result, '^\n\+', '', '')
+	let l:save = @s
 	let @s = l:result
 	let l:result_line_count = len(substitute(l:result, '[^\n]', '', 'g')) + 1
 	if l:result_line_count > 1
@@ -363,6 +366,7 @@ function! SimpleSnippets#initShell(current)
 	endif
 	exe "normal! vf}x"
 	normal! "sP
+	let @s = l:save
 	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
 	if l:repeater_count != 0
 		call SimpleSnippets#initRepeaters(a:current, l:result, l:repeater_count)
@@ -370,6 +374,7 @@ function! SimpleSnippets#initShell(current)
 endfunction
 
 function! SimpleSnippets#initRepeaters(current, content, count)
+	let l:save = @s
 	let @s = a:content
 	let l:repeater_count = a:count
 	let l:i = 0
@@ -383,6 +388,7 @@ function! SimpleSnippets#initRepeaters(current, content, count)
 		normal! "sP
 		let l:i += 1
 	endwhile
+	let @s = l:save
 	call cursor(s:snip_start, 1)
 endfunction
 

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -456,6 +456,7 @@ function! SimpleSnippets#jumpMirror(placeholder)
 			let l:length = col('.') - l:start + 1
 			call add(l:matchpositions, matchaddpos('Visual', [[l:line, l:start, l:length]]))
 			call add(l:matchpositions, matchaddpos('Cursor', [[l:line, l:start + l:length - 1]]))
+			call cursor(line('.'), col('.') + 1)
 			let l:i += 1
 		endwhile
 		call cursor(s:snip_start, 1)

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -238,7 +238,7 @@ function! SimpleSnippets#parseAndInit()
 	let s:type_stack = []
 	let s:active = 1
 	let s:current_file = @%
-	let s:ph_amount = SimpleSnippets#countPlaceholders('\v\$(\{)?[0-9]+(:|!|\|)?')
+	let s:ph_amount = SimpleSnippets#countPlaceholders('\v\$\{[0-9]+(:|!|\|)')
 	if s:ph_amount != 0
 		call SimpleSnippets#parseSnippet(s:ph_amount)
 		if s:snip_line_count != 1
@@ -279,7 +279,7 @@ function! SimpleSnippets#parseSnippet(amount)
 		if l:i == a:amount
 			let l:current = 0
 		endif
-		call search('\v\$(\{)?' . l:current, 'c')
+		call search('\v\$\{' . l:current, 'c')
 		let l:type = SimpleSnippets#getPlaceholderType()
 		call SimpleSnippets#initPlaceholder(l:current, l:type)
 		let l:i += 1
@@ -372,8 +372,11 @@ function! SimpleSnippets#initRepeater(current, content)
 	let l:i = 0
 	while l:i < l:repeater_count
 		call cursor(s:snip_start, 1)
-		call search('\v\$'.a:current, '', s:snip_end)
-		exe "normal! vec"
+		call search('\v\$'.a:current, 'c', s:snip_end)
+		normal! mq
+		call search('\v\$'.a:current, 'ce', s:snip_end)
+		normal! mp
+		exe "normal! `qv`pc"
 		normal! "sp
 		let l:i += 1
 	endwhile

--- a/doc/SimpleSnippets.txt
+++ b/doc/SimpleSnippets.txt
@@ -35,7 +35,8 @@ SimpleSnippets                                   *snippet* *snippets* *SimpleSni
    4.2 Placeholder Syntax ........................ |SimpleSnippets-placeholder-syntax|
      4.2.1 Normal Placeholders ................... |SimpleSnippets-normal-placeholder|
      4.2.2 Mirror Placeholders ................... |SimpleSnippets-mirror-placeholder|
-     4.2.3 Shell Placeholders .................... |SimpleSnippets-shell-placeholder|
+     4.2.3 Command Placeholders .................. |SimpleSnippets-command-placeholder|
+     4.2.4 Repeaters ............................. |SimpleSnippets-repeater|
    4.3 Snippets Examples ......................... |SimpleSnippets-snippet-examples|
 5. Contributing .................................. |SimpleSnippets-contributing|
 
@@ -572,23 +573,25 @@ or `endsnippet` entries are necessary.
                                                *SimpleSnippets-mirror-placeholder*
   4.2.2 Mirror Placeholders
 
-  The implementation of mirrored placeholders in this plugin is very different,
-  form other snippet plugins. Mirrored placeholder's text is applied across
-  whole snippet's body. Thats is, you can define any text, and upon jump to the
-  mirrored placeholder you will be prompted to enter text which you would like to
-  use in snippet's body. For example:
+  Mirrored placeholder shares same syntax as normal and command placeholder, however
+  the implementation of mirrored placeholders in this plugin is very different,
+  form other snippet plugins. What differs `normal` and `shell` placeholder from `mirrored`
+  one is occurrence of |repeater|s. If `repeater` is defined for normal
+  placeholder this placeholder becomes mirrored one. For example:
 
-    `class ${1|Name} {`
+    `class ${1:Name} {`
     `public:`
-    `    Name();`
-    `    virtual ~Name();`
+    `    $1();`
+    `    virtual ~$1();`
 
     `private:`
     `    ${0:/* data */}`
     `};`
 
   The first action of every expand of any snippet is jump. In this case the
-  placeholder, which is being jumped is mirrored type. Which means that we will be
+  placeholder, which is being jumped is `normal` type. However, we can spot
+  `repeater`s of this placeholder, so SimpleSnippets converts `normal`
+  placeholder to `mirrored` placeholder. Upon jump on `${1:Name}` you will be
   prompted to change `Name` to some other text, which suits current situation.
   `Name` will be selected across whole snippet, and you will see such message in
   the command line:
@@ -602,40 +605,22 @@ or `endsnippet` entries are necessary.
   the same way if you would hit <Esc>. Mirrored placeholders are automatically
   executing next jump for you.
 
-  Some note about mirroring in other plugins. ~
+                                              *SimpleSnippets-command-placeholder*
+  4.2.3 Command Placeholders
 
-  I kinda like and in the same way dislike how mirrored snippet are done in
-  various plugins. The main difference here, that for example in UltiSnips the
-  syntax for mirroring is done by definition several placeholders with same jump
-  index. For example look at the syntax of `typedef struct` snippet which I use in
-  UltiSnips when writing in C at work:
-
-    `snippet tstr "typedef struct"`
-    `typedef struct ${1:Name} {`
-    `    $2`
-    `} $1; $0`
-    `endsnippet`
-
-  * This syntax is illegal in SimpleSnippets.~
-
-  At some point it is good, because you're editing it in real-time, and `$1`
-  placeholder is mirrored as you type, so you can see how it will affect
-  snippet's body. In most cases it is better approach, and I highly recommend it
-  as a default one. But in my case it was slowdown of my workflow because of weak
-  hardware, so I've decided to change it to substitution-like method.
-
-                                                *SimpleSnippets-shell-placeholder*
-  4.2.3 Shell Placeholders
-
-  The implementation of shell placeholders relies on Vim's `system()` function.
-  Shell placeholders executes their contents as a command *which can be jumped
-  later, and yank it to your file via `@s` register.
-
-  * Commands that resulting to more then single line of text are currently broke
-  jumping. You can jump tho the next placeholder still, but don't rely on
-  jumping to, for example, `cat /usr/share/licenses/clang/LICENSE` output. It is
-  will still be expanded, but one jump will be missed. For example here is the
-  `uname` snippet:
+  The implementation of command placeholders relies on Vim's `system()` function.
+  Shell placeholders executes their contents as a command *which can't be jumped
+  later, and yank it to your file via `@s` register. If you wan't to jump to
+  such placeholder, consider wrapping it inside normal placeholder like so:
+  `${2:${1!uname}`. This also makes mirroring easy, because nor you can mirror
+  `$1` if you don't want to jump to the results, or `$2` if you want to make
+  this placeholder jumpable and mirrored. However, COmmands that result more
+  then single line of text are currently broke jumping. So if you wan't to yank
+  a file inside snippet's body, don't wrap command placeholder with normal one,
+  because it will break snippet expanding.
+  Example of multiline shell output may be: `${0!cat /usr/share/licenses/clang/LICENSE}`
+  placeholder. It can be expanded, but can't be wrapped in `normal` placeholder.
+  For example here is the `uname` snippet:
 
   `My current Linux Kernel is:`
   `${0!uname --operating-system --kernel-release}`
@@ -645,7 +630,48 @@ or `endsnippet` entries are necessary.
   `My current Linux Kernel is:`
   `4.15.15-1-ARCH GNU/Linux`
 
-                                                 *SimpleSnippets-snippet-examples*
+  Command placeholders also support viml commands. You can use any vim command,
+  that can be echoed. It can be registers, vimscript functions, etc.
+  For example:
+
+  Sippet `file`
+
+    `${0!@%}`
+
+  Which will be expanded to:
+
+    `"currently/edited/filename"`
+  Snippet `FILE`:
+
+    `${0!substitute(@%, '.*', '\U&', 'g')}`
+
+  Which will be expanded to:
+
+    `"CURRENTLY/EDITED/FILENAME"`
+
+  Viml support is currently experimental.
+
+                                                *repeater* *SimpleSnippets-repeater*
+  4.2.4 Repeaters
+
+  Repeaters are used to pepeat placeholder's body across snippet's body. So for
+  example, placeholder `${1:Class_Name}` will be considered as `normal`
+  placeholder. However if we add `$1` placeholder, which is called `repeater`,
+  on snippet expanding that paceholder's body will be substituted to every
+  occurrence of `$1` inside snippet's body. This also will make that placeholder
+  `mirrored` type instead of `normal` type. Repeaters can be used to any kind of
+  placeholder: `normal` and `command`. However these two will behave slightly
+  different, as `command` placeholder will be just substituted but not jumped,
+  therefore command `repeater`s will not be jumped either. You can wrap command
+  placeholder with `normal` placeholder, and use a `repeater`s of `normal`
+  placeholder, to jump and mirror `command` one
+
+  Repeaters was added to change core mechanics for mirroring, to make it more
+  easy and maintainable. This also should add some layer of compability with
+  other snippet managers. Previously mirroring was done with separate
+  placeholder type `${1|text}`, and it's body must have been repeated in
+  snippet's body. Now this is deprecated.
+                                                *SimpleSnippets-snippet-examples*
 4.3 Snippet Examples
 
 Here are some snippets to start with:


### PR DESCRIPTION
This is breaking change. This PR will break all mirrored placeholders, because they're deprecated from now on. Repeaters introduced to make mechanics more similar to other plugins and easier to understand.