### PR TITLE
Multiline search

### DIFF
--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -95,6 +95,12 @@ function! SimpleSnippets#expand()
 	else
 		let l:path = SimpleSnippets#getSnipPath(l:snip, l:filetype)
 		let l:snippet = readfile(l:path)
+		if l:snippet[0] == ''
+			call remove(l:snippet, 0)
+		endif
+		if l:snippet[-1] == ''
+			call remove(l:snippet, -1)
+		endif
 		let s:snip_line_count = len(l:snippet)
 		if s:snip_line_count != 0
 			let l:snippet = join(l:snippet, "\n")
@@ -378,7 +384,9 @@ function! SimpleSnippets#initRepeaters(current, content, count)
 		call search('\v\$'.a:current, 'ce', s:snip_end)
 		normal! mp
 		exe "normal! g`qvg`pr"
-		let s:snip_end += l:amount_of_lines - 1
+		if l:amount_of_lines > 1
+			let s:snip_end += l:amount_of_lines - 1
+		endif
 		normal! "sp
 		let l:i += 1
 	endwhile

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -487,7 +487,7 @@ function! SimpleSnippets#colorMatches(text)
 		let l:ph = join(split(l:ph), "\\n")
 		let l:echo = l:ph
 	elseif a:text !~ "\\W"
-		let l:echo = a:placeholder
+		let l:echo = a:text
 		let l:ph = '\<' . l:ph . '\>'
 	endif
 	redir => l:cnt
@@ -518,14 +518,20 @@ endfunction
 function! SimpleSnippets#edit()
 	let l:filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_similar_filetypes)
 	let l:path = g:SimpleSnippets_search_path . l:filetype
+	let s:snip_edit_buf = 0
 	if !isdirectory(l:path)
 		call mkdir(l:path, "p")
 	endif
 	let l:trigger = input('Select a trigger: ')
 	if l:trigger != ''
 		if win_gotoid(s:snip_edit_win)
-			execute "normal! e " . l:path . '/' . l:trigger
-			execute "setf " . l:filetype
+			try
+				exec "buffer " . s:snip_edit_buf
+			catch
+				let l:trigger = SimpleSnippets#triggerEscape(l:trigger)
+				exec "edit " . l:path . '/' . l:trigger
+				exec "setf " . l:filetype
+			endtry
 		else
 			vertical new
 			try

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -348,7 +348,12 @@ function! SimpleSnippets#initCommand(current)
 	let @s = l:save_s
 	let @" = l:save_quote
 	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
-	if l:repeater_count != 0
+	call add(s:jump_stack, l:result)
+	if l:repeater_count != 0 && l:result_line_count == 1
+		call add(s:type_stack, 2)
+		call SimpleSnippets#initRepeaters(a:current, l:result, l:repeater_count)
+	else
+		call add(s:type_stack, 1)
 		call SimpleSnippets#initRepeaters(a:current, l:result, l:repeater_count)
 	endif
 endfunction
@@ -423,9 +428,9 @@ function! SimpleSnippets#jumpNormal(placeholder)
 		let ph = '\<' . ph . '\>'
 	endif
 	call cursor(s:snip_start, 1)
-	call search(ph, 'c', s:snip_end)
+	call search(split(ph)[0], 'c', s:snip_end)
 	normal! mq
-	call search(ph, 'ce', s:snip_end)
+	call search(split(ph)[-1], 'ce', s:snip_end)
 	normal! mp
 	exec "normal! g`qvg`p\<c-g>"
 endfunction
@@ -482,7 +487,9 @@ function! SimpleSnippets#jumpMirror(placeholder)
 	if l:reenable_cursorline == 1
 		set cursorline
 	endif
-	call SimpleSnippets#jump()
+	if s:jump_stack != []
+		call SimpleSnippets#jump()
+	endif
 endfunction
 
 function! SimpleSnippets#edit()

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -426,14 +426,18 @@ function! SimpleSnippets#jumpToLastPlaceholder()
 endfunction
 
 function! SimpleSnippets#jumpNormal(placeholder)
-	let ph = a:placeholder
-	if ph !~ "\\W"
-		let ph = '\<' . ph . '\>'
-	endif
+	let l:ph = a:placeholder
 	call cursor(s:snip_start, 1)
-	call search(split(ph)[0], 'c', s:snip_end)
+	if l:ph =~ "\\n"
+		let l:ph = join(split(l:ph), "\\n")
+		let l:echo = l:ph
+	elseif l:ph !~ "\\W"
+		let l:echo = a:placeholder
+		let l:ph = '\<' . l:ph . '\>'
+	endif
+	call search(split(l:ph, '\\n')[0], 'c', s:snip_end)
 	normal! mq
-	call search(split(ph)[-1], 'ce', s:snip_end)
+	call search(split(l:ph, '\\n')[-1], 'ce', s:snip_end)
 	normal! mp
 	exec "normal! g`qvg`p\<c-g>"
 endfunction

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -95,12 +95,12 @@ function! SimpleSnippets#expand()
 	else
 		let l:path = SimpleSnippets#getSnipPath(l:snip, l:filetype)
 		let l:snippet = readfile(l:path)
-		if l:snippet[0] == ''
+		while l:snippet[0] == ''
 			call remove(l:snippet, 0)
-		endif
-		if l:snippet[-1] == ''
+		endwhile
+		while l:snippet[-1] == ''
 			call remove(l:snippet, -1)
-		endif
+		endwhile
 		let s:snip_line_count = len(l:snippet)
 		if s:snip_line_count != 0
 			let l:snippet = join(l:snippet, "\n")


### PR DESCRIPTION
**Description**
Now multi-line command placeholders are available for jumping. Also mirroring of multi-line command placeholders is now possible. Command placeholders are jump-able again. Nesting is no longer needed.

**Breaking change:** yes
