### PR TITLE
Refactoring and fallback trigger lookup mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ languages.
 Here I'll try to list all limitations that you may encounter when using Simple Snippets:
 
 - [ ] No tabstops.  
-Why? Because jumping is based on text searching. Because placeholders are deleted from snippet body when it is pasted to your file there is no way to find empty ones, because text behind them for example may change. If NeoVim will add ability to use multicursor and position it in text like in other modern editors this may be implemented. Because of this limitation mirroring is done differently too.
+Why? Well, jumping is based on text searching. Because placeholders are deleted from snippet body when it is pasted to your file there is no way to find empty ones, because text behind them for example may change. If NeoVim will add ability to use multicursor and position it in text like in other modern editors this may be implemented. Because of this limitation mirroring is done differently too.
 - [ ] Placeholders have slightly different syntax than other plugins use.  
 SimpleSnippets supports normal: `${1:text}`, command: `${2!command}`, and repeater `$3` placeholders.
 - [ ] Normal placeholders should contain per snippet unique bodies.  
@@ -123,14 +123,13 @@ As was already said before. So if you replace some part of snippets in the same 
 Because of previous point. Actually I don't know how to get last user input to store it in vimscript to search for it inside snippet body.
 - [ ] Single snippet editing at time.
 If you expanded a snippet, and you try to expand snippet inside this one, you will lose ability to jump in your previous snippet.
-- [ ] Trigger must be separated from everything  
-I couldn't come up with a way of getting user input trigger better way, so it would be possible to use both `#if` and `if` triggers, therefore `(if`<kbd>Tab</kbd>`)` will be considered as `(if` trigger. I'm trying to do something with this right now.
 - [ ] No nested placeholders.
 - There may be more, which I've not thought about.
 
 **Withdrawn limitations:**
 - [x] Every snippet **must** contain zero indexed placeholder, aka `${0:text}`
 - [x] Command placeholders, that output is more then single line can't be jumped.
+- [x] Trigger must be separated from everything
 
 After reading this list you may want to ask me this question:
 

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -63,15 +63,12 @@ function! SimpleSnippets#expand()
 			let l:save_s = @s
 			let @s = l:snippet
 			let l:save_quote = @"
+			sleep 2
 			if l:snip =~ "\\W"
-				let l:delete = l:snip
+				normal! ciW
 			else
-				let l:delete = '<' . l:snip . '>'
+				normal! ciw
 			endif
-			"let s:trigger = matchstr(getline('.'), '\v(\w+|(\s+)@!\W+(\s)@<!(\w+)?)%' . l:col . 'c.')
-			execute line('.') . ',' . line('.') . 's/\v(.*)' . l:delete . '%' . col('.'). 'c./\1snippet/'
-			call search('snippet', 'c', line('.'))
-			normal! ciw
 			normal! "sp
 			let @" = l:save_quote
 			let @s = l:save_s
@@ -85,14 +82,10 @@ endfunction
 function! SimpleSnippets#expandFlashSnippet(snip)
 	let l:save_quote = @"
 	if a:snip =~ "\\W"
-		let l:delete = a:snip
+		normal! ciW
 	else
-		let l:delete = '<' . a:snip . '>'
+		normal! ciw
 	endif
-	execute line('.') . ',' . line('.') . 's/\v(.*)' . l:delete . '/\1snippet/'
-	call search('snippet', 'c', line('.'))
-	normal! ciw
-	let l:save_quote = @"
 	let l:save_s = @s
 	let @s = s:flash_snippets[a:snip]
 	let s:snip_line_count = len(substitute(s:flash_snippets[a:snip], '[^\n]', '', 'g')) + 1
@@ -273,7 +266,6 @@ endfunction
 
 function! SimpleSnippets#obtainAlternateTrigger()
 	if mode() == 'i'
-		call cursor(line('.'), col('.') - 1)
 		let s:trigger = expand("<cword>")
 	else
 		let s:trigger = expand("<cword>")

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -68,7 +68,8 @@ function! SimpleSnippets#expand()
 			else
 				let l:delete = '<' . l:snip . '>'
 			endif
-			execute line('.') . ',' . line('.') . 's/\v(.*)' . l:delete . '/\1snippet/'
+			"let s:trigger = matchstr(getline('.'), '\v(\w+|(\s+)@!\W+(\s)@<!(\w+)?)%' . l:col . 'c.')
+			execute line('.') . ',' . line('.') . 's/\v(.*)' . l:delete . '%' . col('.'). 'c./\1snippet/'
 			call search('snippet', 'c', line('.'))
 			normal! ciw
 			normal! "sp

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -84,10 +84,13 @@ endfunction
 function! SimpleSnippets#expandFlashSnippet(snip)
 	let l:save_quote = @"
 	if a:snip =~ "\\W"
-		normal! ciW
+		let l:delete = a:snip
 	else
-		normal! ciw
+		let l:delete = '<' . a:snip . '>'
 	endif
+	execute line('.') . ',' . line('.') . 's/\v(.*)' . l:delete . '/\1snippet/'
+	call search('snippet', 'c', line('.'))
+	normal! ciw
 	let l:save_quote = @"
 	let l:save_s = @s
 	let @s = s:flash_snippets[a:snip]

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -13,36 +13,11 @@ let s:jump_stack = []
 let s:type_stack = []
 
 "Functions
-function! SimpleSnippets#isExpandable()
-	call SimpleSnippets#obtainTrigger()
-	if SimpleSnippets#getSnipFileType(s:trigger) != -1
-		return 1
-	endif
-	call SimpleSnippets#obtainAlternateTrigger()
-	if SimpleSnippets#getSnipFileType(s:trigger) != -1
-		return 1
-	endif
-	let s:trigger = ''
-	return 0
-endfunction
-
-function! SimpleSnippets#obtainTrigger()
-	if s:trigger == ''
-		if mode() == 'i'
-			call cursor(line('.'), col('.') - 1)
-			let s:trigger = expand("<cWORD>")
-		else
-			let s:trigger = expand("<cWORD>")
-		endif
-	endif
-endfunction
-
-function! SimpleSnippets#obtainAlternateTrigger()
-	if mode() == 'i'
-		call cursor(line('.'), col('.') - 1)
-		let s:trigger = expand("<cword>")
-	else
-		let s:trigger = expand("<cword>")
+function! SimpleSnippets#expandOrJump()
+	if SimpleSnippets#isExpandable()
+		call SimpleSnippets#expand()
+	elseif SimpleSnippets#isJumpable()
+		call SimpleSnippets#jump()
 	endif
 endfunction
 
@@ -65,35 +40,6 @@ function! SimpleSnippets#isJumpable()
 	endif
 	let s:active = 0
 	return 0
-endfunction
-
-function! SimpleSnippets#isInside()
-	if s:current_file == @%
-		let l:current_line = line(".")
-		if l:current_line >= s:snip_start && l:current_line <= s:snip_end
-			return 1
-		else
-			return 0
-		endif
-	endif
-	let s:active = 0
-	return 0
-endfunction
-
-function! SimpleSnippets#isActive()
-	if s:active == 1
-		return 1
-	else
-		return 0
-	endif
-endfunction
-
-function! SimpleSnippets#expandOrJump()
-	if SimpleSnippets#isExpandable()
-		call SimpleSnippets#expand()
-	elseif SimpleSnippets#isJumpable()
-		call SimpleSnippets#jump()
-	endif
 endfunction
 
 function! SimpleSnippets#expand()
@@ -157,81 +103,6 @@ function! SimpleSnippets#expandFlashSnippet(snip)
 	silent call SimpleSnippets#parseAndInit()
 endfunction
 
-function! SimpleSnippets#checkExternalSnippets()
-	if !exists('s:plugin_checked')
-		let s:plugin_checked = 1
-		if exists('g:SimpleSnippets_snippets_plugin_path')
-			let s:SimpleSnippets_snippets_plugin_installed = 1
-		else
-			let s:SimpleSnippets_snippets_plugin_installed = 0
-		endif
-	endif
-endfunction
-
-function! SimpleSnippets#getSnipFileType(snip)
-	call SimpleSnippets#checkExternalSnippets()
-	let l:filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_similar_filetypes)
-	if filereadable(g:SimpleSnippets_search_path . l:filetype . '/' . a:snip)
-		return l:filetype
-	endif
-	if SimpleSnippets#checkFlashSnippets(a:snip)
-		return 'flash'
-	endif
-	if s:SimpleSnippets_snippets_plugin_installed == 1
-		let l:plugin_filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_snippets_similar_filetypes)
-		if filereadable(g:SimpleSnippets_snippets_plugin_path . l:plugin_filetype . '/' . a:snip)
-			return l:plugin_filetype
-		endif
-	endif
-	if filereadable(g:SimpleSnippets_search_path . 'all/' . a:snip)
-		return 'all'
-	endif
-	if s:SimpleSnippets_snippets_plugin_installed == 1
-		if filereadable(g:SimpleSnippets_snippets_plugin_path . 'all/' . a:snip)
-			return 'all'
-		endif
-	endif
-	return -1
-endfunction
-
-function! SimpleSnippets#getSnipPath(snip, filetype)
-	if filereadable(g:SimpleSnippets_search_path . a:filetype . '/' . a:snip)
-		return g:SimpleSnippets_search_path . a:filetype . '/' . a:snip
-	elseif s:SimpleSnippets_snippets_plugin_installed == 1
-		if filereadable(g:SimpleSnippets_snippets_plugin_path . a:filetype . '/' . a:snip)
-			return g:SimpleSnippets_snippets_plugin_path . a:filetype . '/' . a:snip
-		endif
-	endif
-endfunction
-
-function! SimpleSnippets#triggerEscape(trigger)
-	if a:trigger =~ "\\W"
-		return escape(a:trigger, '/\*#|{}()"'."'")
-	else
-		return a:trigger
-	endif
-endfunction
-
-function! SimpleSnippets#checkFlashSnippets(snip)
-	if has_key(s:flash_snippets, a:snip)
-		return 1
-	endif
-	return 0
-endfunction
-
-function! SimpleSnippets#filetypeWrapper(similar_filetypes)
-	let l:ft = &ft
-	if l:ft == ''
-		return 'all'
-	endif
-	for l:filetypes in a:similar_filetypes
-		if index(l:filetypes, l:ft) != -1
-			return l:filetypes[0]
-		endif
-	endfor
-	return l:ft
-endfunction
-
 function! SimpleSnippets#parseAndInit()
 	let s:jump_stack = []
 	let s:type_stack = []
@@ -257,157 +128,6 @@ function! SimpleSnippets#parseAndInit()
 	else
 		let s:active = 0
 		call cursor(l:cursor_pos[1], l:cursor_pos[2])
-	endif
-endfunction
-
-function! SimpleSnippets#countPlaceholders(pattern)
-	redir => l:cnt
-	silent! exe '%s/' . a:pattern . '//gn'
-	redir END
-	if match(l:cnt, 'not found') >= 0
-		return 0
-	endif
-	let l:count = strpart(l:cnt, 0, stridx(l:cnt, " "))
-	let l:count = substitute(l:count, '\v%^\_s+|\_s+%$', '', 'g')
-	return l:count
-endfunction
-
-function! SimpleSnippets#parseSnippet(amount)
-	let l:type = 0
-	let l:i = 1
-	let l:max = a:amount + 1
-	let l:current = l:i
-	let s:snip_start = line(".")
-	let s:snip_end = s:snip_start + s:snip_line_count - 1
-	while l:i <= l:max
-		call cursor(s:snip_start, 1)
-		if l:i == l:max
-			let l:current = 0
-		endif
-		if search('\v\$\{' . l:current, 'c') != 0
-			let l:type = SimpleSnippets#getPlaceholderType()
-			call SimpleSnippets#initPlaceholder(l:current, l:type)
-		endif
-		let l:i += 1
-		let l:current = l:i
-	endwhile
-endfunction
-
-function! SimpleSnippets#addFlashSnippet(trigger, snippet_defenition)
-	let s:flash_snippets[a:trigger] = a:snippet_defenition
-endfunction
-
-function! SimpleSnippets#removeFlashSnippet(trigger)
-	let l:i = 0
-	if has_key(s:flash_snippets, a:trigger)
-		unlet![a:trigger]
-	endif
-endfunction
-
-function! SimpleSnippets#getPlaceholderType()
-	let l:col = col('.')
-	let l:ph = matchstr(getline('.'), '\v%'.l:col.'c\$\{[0-9]+.{-}\}')
-	if match(l:ph, '\v\$\{[0-9]+:.{-}\}') == 0
-		return 1
-	elseif match(l:ph, '\v\$\{[0-9]+!.{-}\}') == 0
-		return 2
-	endif
-endfunction
-
-function! SimpleSnippets#initPlaceholder(current, type)
-	if a:type == 1
-		call SimpleSnippets#initNormal(a:current)
-	elseif a:type == 2
-		call SimpleSnippets#initCommand(a:current)
-	endif
-endfunction
-
-function! SimpleSnippets#initNormal(current)
-	let l:placeholder = '\v(\$\{'. a:current . ':)@<=.{-}(\})@='
-	let l:result = matchstr(getline('.'), l:placeholder)
-	call add(s:jump_stack, l:result)
-	let l:save_quote = @"
-	exe "normal! df:f}i\<Del>\<Esc>"
-	let @" = l:save_quote
-	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
-	if l:repeater_count != 0
-		call add(s:type_stack, 3)
-		call SimpleSnippets#initRepeaters(a:current, l:result, l:repeater_count)
-	else
-		call add(s:type_stack, 1)
-	endif
-endfunction
-
-function! SimpleSnippets#initCommand(current)
-	let l:save_quote = @"
-	let l:placeholder = '\v(\$\{'. a:current . '!)@<=.{-}(\})@='
-	let l:command = matchstr(getline('.'), l:placeholder)
-	if executable(substitute(l:command, '\v(^\w+).*', '\1', 'g')) == 1
-		let l:result = system(l:command)
-	else
-		let l:result = execute("echo " . l:command, "silent!")
-		if l:result == ''
-			let l:result = l:command
-		endif
-	endif
-	let l:result = SimpleSnippets#removeTrailings(l:result)
-	let l:save_s = @s
-	let @s = l:result
-	let l:result_line_count = len(substitute(l:result, '[^\n]', '', 'g')) + 1
-	if l:result_line_count > 1
-		let s:snip_end += l:result_line_count
-	endif
-	normal! mq
-	call search('\v\$\{'.a:current.'!.{-}\}', 'ce', s:snip_end)
-	normal! mp
-	exe "normal! g`qvg`pr"
-	normal! "sp
-	let @s = l:save_s
-	let @" = l:save_quote
-	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
-	call add(s:jump_stack, l:result)
-	if l:repeater_count != 0
-		call add(s:type_stack, 3)
-		call SimpleSnippets#initRepeaters(a:current, l:result, l:repeater_count)
-	else
-		call add(s:type_stack, 1)
-	endif
-	noh
-endfunction
-
-function! SimpleSnippets#removeTrailings(text)
-	let l:result = substitute(a:text, '\n\+$', '', '')
-	let l:result = substitute(l:result, '\s\+$', '', '')
-	let l:result = substitute(l:result, '^\s\+', '', '')
-	let l:result = substitute(l:result, '^\n\+', '', '')
-	return l:result
-endfunction
-
-function! SimpleSnippets#initRepeaters(current, content, count)
-	let l:save_s = @s
-	let l:save_quote = @"
-	let @s = a:content
-	let l:repeater_count = a:count
-	let l:amount_of_lines = len(split(a:content, "\\n"))
-	let l:i = 0
-	while l:i < l:repeater_count
-		call cursor(s:snip_start, 1)
-		call search('\v\$'.a:current, 'c', s:snip_end)
-		normal! mq
-		call search('\v\$'.a:current, 'ce', s:snip_end)
-		normal! mp
-		exe "normal! g`qvg`pr"
-		if l:amount_of_lines > 1
-			let s:snip_end += l:amount_of_lines - 1
-		endif
-		normal! "sp
-		let l:i += 1
-	endwhile
-	let @s = l:save_s
-	let @" = l:save_quote
-	call cursor(s:snip_start, 1)
-	if l:amount_of_lines != 1
-		let s:snip_end -= 1
 	endif
 endfunction
 
@@ -510,38 +230,157 @@ function! SimpleSnippets#jumpMirror(placeholder)
 	endif
 endfunction
 
-function! SimpleSnippets#colorMatches(text)
-	let l:ph = a:text
-	if l:ph =~ "\\n"
-		let l:ph = join(split(l:ph), "\\n")
-		let l:echo = l:ph
-	elseif a:text !~ "\\W"
-		let l:echo = a:text
-		let l:ph = '\<' . l:ph . '\>'
+function! SimpleSnippets#isInside()
+	if s:current_file == @%
+		let l:current_line = line(".")
+		if l:current_line >= s:snip_start && l:current_line <= s:snip_end
+			return 1
+		else
+			return 0
+		endif
 	endif
-	redir => l:cnt
-	silent! exe s:snip_start.','.s:snip_end.'s/' . a:text . '//gn'
-	redir END
-	noh
-	let l:count = strpart(l:cnt, 0, stridx(l:cnt, " "))
-	let l:count = substitute(l:count, '\v%^\_s+|\_s+%$', '', 'g')
-	let l:i = 0
-	let l:matchpositions = []
-	call cursor(s:snip_start, 1)
-	while l:i < l:count
-		for l:lin in split(a:text, '\\n')
-			call search(l:lin, 'cW', s:snip_end)
-			let l:line = line('.')
-			let l:start = col('.')
-			call search(l:lin, 'ceW', s:snip_end)
-			let l:length = col('.') - l:start + 1
-			call add(l:matchpositions, matchaddpos('Visual', [[l:line, l:start, l:length]]))
-			call cursor(line('.'), col('.') + 1)
+	let s:active = 0
+	return 0
+endfunction
+
+function! SimpleSnippets#isExpandable()
+	call SimpleSnippets#obtainTrigger()
+	if SimpleSnippets#getSnipFileType(s:trigger) != -1
+		return 1
+	endif
+	call SimpleSnippets#obtainAlternateTrigger()
+	if SimpleSnippets#getSnipFileType(s:trigger) != -1
+		return 1
+	endif
+	let s:trigger = ''
+	return 0
+endfunction
+
+function! SimpleSnippets#obtainTrigger()
+	if s:trigger == ''
+		if mode() == 'i'
+			call cursor(line('.'), col('.') - 1)
+			let s:trigger = expand("<cWORD>")
+		else
+			let s:trigger = expand("<cWORD>")
+		endif
+	endif
+endfunction
+
+function! SimpleSnippets#obtainAlternateTrigger()
+	if mode() == 'i'
+		call cursor(line('.'), col('.') - 1)
+		let s:trigger = expand("<cword>")
+	else
+		let s:trigger = expand("<cword>")
+	endif
+endfunction
+
+function! SimpleSnippets#isActive()
+	if s:active == 1
+		return 1
+	else
+		return 0
+	endif
+endfunction
+
+function! SimpleSnippets#getSnipFileType(snip)
+	call SimpleSnippets#checkExternalSnippets()
+	let l:filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_similar_filetypes)
+	if filereadable(g:SimpleSnippets_search_path . l:filetype . '/' . a:snip)
+		return l:filetype
+	endif
+	if SimpleSnippets#checkFlashSnippets(a:snip)
+		return 'flash'
+	endif
+	if s:SimpleSnippets_snippets_plugin_installed == 1
+		let l:plugin_filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_snippets_similar_filetypes)
+		if filereadable(g:SimpleSnippets_snippets_plugin_path . l:plugin_filetype . '/' . a:snip)
+			return l:plugin_filetype
+		endif
+	endif
+	if filereadable(g:SimpleSnippets_search_path . 'all/' . a:snip)
+		return 'all'
+	endif
+	if s:SimpleSnippets_snippets_plugin_installed == 1
+		if filereadable(g:SimpleSnippets_snippets_plugin_path . 'all/' . a:snip)
+			return 'all'
+		endif
+	endif
+	return -1
+endfunction
+
+function! SimpleSnippets#listSnippets()
+	let l:filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_similar_filetypes)
+	call SimpleSnippets#checkExternalSnippets()
+	let l:user_snips = g:SimpleSnippets_search_path
+	call SimpleSnippets#printSnippets("User snippets:", l:user_snips, l:filetype)
+	if s:flash_snippets != {}
+		let l:string = ''
+		echo 'Flash snippets:'
+		for snippet in s:flash_snippets
+			let l:item = join(snippet, ": ")
+			let l:string .= l:item .'\n'
 		endfor
-		call add(l:matchpositions, matchaddpos('Cursor', [[l:line, l:start + l:length - 1]]))
-		let l:i += 1
-	endwhile
-	return l:matchpositions
+		echo system('echo ' . shellescape(l:string) . '| nl')
+	endif
+	if s:SimpleSnippets_snippets_plugin_installed == 1
+		let l:plug_snips = g:SimpleSnippets_snippets_plugin_path
+		let l:plugin_filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_snippets_similar_filetypes)
+		call SimpleSnippets#printSnippets("Plugin snippets:", l:plug_snips, l:plugin_filetype)
+	endif
+	if l:filetype != 'all'
+		call SimpleSnippets#printSnippets('User \"all\" snippets:', l:user_snips, 'all')
+		if s:SimpleSnippets_snippets_plugin_installed == 1
+			call SimpleSnippets#printSnippets('Plugin \"all\" snippets:', l:plug_snips, 'all')
+		endif
+	endif
+endfunction
+
+function! SimpleSnippets#availableSnippets()
+	call SimpleSnippets#checkExternalSnippets()
+	let l:filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_similar_filetypes)
+	let l:snippets = {}
+	let l:user_snips = g:SimpleSnippets_search_path
+	let l:snippets = SimpleSnippets#getSnippetDict(l:snippets, l:user_snips, l:filetype)
+	if s:SimpleSnippets_snippets_plugin_installed == 1
+		let l:plugin_filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_snippets_similar_filetypes)
+		let l:plug_snips = g:SimpleSnippets_snippets_plugin_path
+		let l:snippets = SimpleSnippets#getSnippetDict(l:snippets, l:plug_snips, l:plugin_filetype)
+	endif
+	if l:filetype != 'all'
+		let l:snippets = SimpleSnippets#getSnippetDict(l:snippets, l:user_snips, 'all')
+		if s:SimpleSnippets_snippets_plugin_installed == 1
+			let l:snippets = SimpleSnippets#getSnippetDict(l:snippets, l:plug_snips, 'all')
+		endif
+	endif
+	if s:flash_snippets != {}
+		for trigger in keys(s:flash_snippets)
+			let l:snippets[trigger] = substitute(s:flash_snippets[trigger], '\v\$\{[0-9]+(:|!)(.{-})\}', '\2', 'g')
+		endfor
+	endif
+	return l:snippets
+endfunction
+
+function! SimpleSnippets#checkExternalSnippets()
+	if !exists('s:plugin_checked')
+		let s:plugin_checked = 1
+		if exists('g:SimpleSnippets_snippets_plugin_path')
+			let s:SimpleSnippets_snippets_plugin_installed = 1
+		else
+			let s:SimpleSnippets_snippets_plugin_installed = 0
+		endif
+	endif
+endfunction
+
+function! SimpleSnippets#getSnipPath(snip, filetype)
+	if filereadable(g:SimpleSnippets_search_path . a:filetype . '/' . a:snip)
+		return g:SimpleSnippets_search_path . a:filetype . '/' . a:snip
+	elseif s:SimpleSnippets_snippets_plugin_installed == 1
+		if filereadable(g:SimpleSnippets_snippets_plugin_path . a:filetype . '/' . a:snip)
+			return g:SimpleSnippets_snippets_plugin_path . a:filetype . '/' . a:snip
+		endif
+	endif
 endfunction
 
 function! SimpleSnippets#edit()
@@ -576,31 +415,217 @@ function! SimpleSnippets#edit()
 	endif
 endfunction
 
-function! SimpleSnippets#listSnippets()
-	let l:filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_similar_filetypes)
-	call SimpleSnippets#checkExternalSnippets()
-	let l:user_snips = g:SimpleSnippets_search_path
-	call SimpleSnippets#printSnippets("User snippets:", l:user_snips, l:filetype)
-	if s:flash_snippets != {}
-		let l:string = ''
-		echo 'Flash snippets:'
-		for snippet in s:flash_snippets
-			let l:item = join(snippet, ": ")
-			let l:string .= l:item .'\n'
-		endfor
-		echo system('echo ' . shellescape(l:string) . '| nl')
+function! SimpleSnippets#triggerEscape(trigger)
+	if a:trigger =~ "\\W"
+		return escape(a:trigger, '/\*#|{}()"'."'")
+	else
+		return a:trigger
 	endif
-	if s:SimpleSnippets_snippets_plugin_installed == 1
-		let l:plug_snips = g:SimpleSnippets_snippets_plugin_path
-		let l:plugin_filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_snippets_similar_filetypes)
-		call SimpleSnippets#printSnippets("Plugin snippets:", l:plug_snips, l:plugin_filetype)
+endfunction
+
+function! SimpleSnippets#checkFlashSnippets(snip)
+	if has_key(s:flash_snippets, a:snip)
+		return 1
 	endif
-	if l:filetype != 'all'
-		call SimpleSnippets#printSnippets('User \"all\" snippets:', l:user_snips, 'all')
-		if s:SimpleSnippets_snippets_plugin_installed == 1
-			call SimpleSnippets#printSnippets('Plugin \"all\" snippets:', l:plug_snips, 'all')
+	return 0
+endfunction
+
+function! SimpleSnippets#filetypeWrapper(similar_filetypes)
+	let l:ft = &ft
+	if l:ft == ''
+		return 'all'
+	endif
+	for l:filetypes in a:similar_filetypes
+		if index(l:filetypes, l:ft) != -1
+			return l:filetypes[0]
+		endif
+	endfor
+	return l:ft
+endfunction
+
+function! SimpleSnippets#initNormal(current)
+	let l:placeholder = '\v(\$\{'. a:current . ':)@<=.{-}(\})@='
+	let l:result = matchstr(getline('.'), l:placeholder)
+	call add(s:jump_stack, l:result)
+	let l:save_quote = @"
+	exe "normal! df:f}i\<Del>\<Esc>"
+	let @" = l:save_quote
+	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
+	if l:repeater_count != 0
+		call add(s:type_stack, 3)
+		call SimpleSnippets#initRepeaters(a:current, l:result, l:repeater_count)
+	else
+		call add(s:type_stack, 1)
+	endif
+endfunction
+
+function! SimpleSnippets#initCommand(current)
+	let l:save_quote = @"
+	let l:placeholder = '\v(\$\{'. a:current . '!)@<=.{-}(\})@='
+	let l:command = matchstr(getline('.'), l:placeholder)
+	if executable(substitute(l:command, '\v(^\w+).*', '\1', 'g')) == 1
+		let l:result = system(l:command)
+	else
+		let l:result = execute("echo " . l:command, "silent!")
+		if l:result == ''
+			let l:result = l:command
 		endif
 	endif
+	let l:result = SimpleSnippets#removeTrailings(l:result)
+	let l:save_s = @s
+	let @s = l:result
+	let l:result_line_count = len(substitute(l:result, '[^\n]', '', 'g')) + 1
+	if l:result_line_count > 1
+		let s:snip_end += l:result_line_count
+	endif
+	normal! mq
+	call search('\v\$\{'.a:current.'!.{-}\}', 'ce', s:snip_end)
+	normal! mp
+	exe "normal! g`qvg`pr"
+	normal! "sp
+	let @s = l:save_s
+	let @" = l:save_quote
+	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
+	call add(s:jump_stack, l:result)
+	if l:repeater_count != 0
+		call add(s:type_stack, 3)
+		call SimpleSnippets#initRepeaters(a:current, l:result, l:repeater_count)
+	else
+		call add(s:type_stack, 1)
+	endif
+	noh
+endfunction
+
+function! SimpleSnippets#countPlaceholders(pattern)
+	redir => l:cnt
+	silent! exe '%s/' . a:pattern . '//gn'
+	redir END
+	if match(l:cnt, 'not found') >= 0
+		return 0
+	endif
+	let l:count = strpart(l:cnt, 0, stridx(l:cnt, " "))
+	let l:count = substitute(l:count, '\v%^\_s+|\_s+%$', '', 'g')
+	return l:count
+endfunction
+
+function! SimpleSnippets#parseSnippet(amount)
+	let l:type = 0
+	let l:i = 1
+	let l:max = a:amount + 1
+	let l:current = l:i
+	let s:snip_start = line(".")
+	let s:snip_end = s:snip_start + s:snip_line_count - 1
+	while l:i <= l:max
+		call cursor(s:snip_start, 1)
+		if l:i == l:max
+			let l:current = 0
+		endif
+		if search('\v\$\{' . l:current, 'c') != 0
+			let l:type = SimpleSnippets#getPlaceholderType()
+			call SimpleSnippets#initPlaceholder(l:current, l:type)
+		endif
+		let l:i += 1
+		let l:current = l:i
+	endwhile
+endfunction
+
+function! SimpleSnippets#addFlashSnippet(trigger, snippet_defenition)
+	let s:flash_snippets[a:trigger] = a:snippet_defenition
+endfunction
+
+function! SimpleSnippets#removeFlashSnippet(trigger)
+	let l:i = 0
+	if has_key(s:flash_snippets, a:trigger)
+		unlet![a:trigger]
+	endif
+endfunction
+
+function! SimpleSnippets#getPlaceholderType()
+	let l:col = col('.')
+	let l:ph = matchstr(getline('.'), '\v%'.l:col.'c\$\{[0-9]+.{-}\}')
+	if match(l:ph, '\v\$\{[0-9]+:.{-}\}') == 0
+		return 1
+	elseif match(l:ph, '\v\$\{[0-9]+!.{-}\}') == 0
+		return 2
+	endif
+endfunction
+
+function! SimpleSnippets#initPlaceholder(current, type)
+	if a:type == 1
+		call SimpleSnippets#initNormal(a:current)
+	elseif a:type == 2
+		call SimpleSnippets#initCommand(a:current)
+	endif
+endfunction
+
+function! SimpleSnippets#removeTrailings(text)
+	let l:result = substitute(a:text, '\n\+$', '', '')
+	let l:result = substitute(l:result, '\s\+$', '', '')
+	let l:result = substitute(l:result, '^\s\+', '', '')
+	let l:result = substitute(l:result, '^\n\+', '', '')
+	return l:result
+endfunction
+
+function! SimpleSnippets#initRepeaters(current, content, count)
+	let l:save_s = @s
+	let l:save_quote = @"
+	let @s = a:content
+	let l:repeater_count = a:count
+	let l:amount_of_lines = len(split(a:content, "\\n"))
+	let l:i = 0
+	while l:i < l:repeater_count
+		call cursor(s:snip_start, 1)
+		call search('\v\$'.a:current, 'c', s:snip_end)
+		normal! mq
+		call search('\v\$'.a:current, 'ce', s:snip_end)
+		normal! mp
+		exe "normal! g`qvg`pr"
+		if l:amount_of_lines > 1
+			let s:snip_end += l:amount_of_lines - 1
+		endif
+		normal! "sp
+		let l:i += 1
+	endwhile
+	let @s = l:save_s
+	let @" = l:save_quote
+	call cursor(s:snip_start, 1)
+	if l:amount_of_lines != 1
+		let s:snip_end -= 1
+	endif
+endfunction
+
+function! SimpleSnippets#colorMatches(text)
+	let l:ph = a:text
+	if l:ph =~ "\\n"
+		let l:ph = join(split(l:ph), "\\n")
+		let l:echo = l:ph
+	elseif a:text !~ "\\W"
+		let l:echo = a:text
+		let l:ph = '\<' . l:ph . '\>'
+	endif
+	redir => l:cnt
+	silent! exe s:snip_start.','.s:snip_end.'s/' . a:text . '//gn'
+	redir END
+	noh
+	let l:count = strpart(l:cnt, 0, stridx(l:cnt, " "))
+	let l:count = substitute(l:count, '\v%^\_s+|\_s+%$', '', 'g')
+	let l:i = 0
+	let l:matchpositions = []
+	call cursor(s:snip_start, 1)
+	while l:i < l:count
+		for l:lin in split(a:text, '\\n')
+			call search(l:lin, 'cW', s:snip_end)
+			let l:line = line('.')
+			let l:start = col('.')
+			call search(l:lin, 'ceW', s:snip_end)
+			let l:length = col('.') - l:start + 1
+			call add(l:matchpositions, matchaddpos('Visual', [[l:line, l:start, l:length]]))
+			call cursor(line('.'), col('.') + 1)
+		endfor
+		call add(l:matchpositions, matchaddpos('Cursor', [[l:line, l:start + l:length - 1]]))
+		let l:i += 1
+	endwhile
+	return l:matchpositions
 endfunction
 
 function! SimpleSnippets#printSnippets(message, path, filetype)
@@ -642,31 +667,6 @@ function! SimpleSnippets#printSnippets(message, path, filetype)
 		echo system('echo -n ' . shellescape(l:string) . '| nl')
 		echo system('echo ')
 	endif
-endfunction
-
-function! SimpleSnippets#availableSnippets()
-	call SimpleSnippets#checkExternalSnippets()
-	let l:filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_similar_filetypes)
-	let l:snippets = {}
-	let l:user_snips = g:SimpleSnippets_search_path
-	let l:snippets = SimpleSnippets#getSnippetDict(l:snippets, l:user_snips, l:filetype)
-	if s:SimpleSnippets_snippets_plugin_installed == 1
-		let l:plugin_filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_snippets_similar_filetypes)
-		let l:plug_snips = g:SimpleSnippets_snippets_plugin_path
-		let l:snippets = SimpleSnippets#getSnippetDict(l:snippets, l:plug_snips, l:plugin_filetype)
-	endif
-	if l:filetype != 'all'
-		let l:snippets = SimpleSnippets#getSnippetDict(l:snippets, l:user_snips, 'all')
-		if s:SimpleSnippets_snippets_plugin_installed == 1
-			let l:snippets = SimpleSnippets#getSnippetDict(l:snippets, l:plug_snips, 'all')
-		endif
-	endif
-	if s:flash_snippets != {}
-		for trigger in keys(s:flash_snippets)
-			let l:snippets[trigger] = substitute(s:flash_snippets[trigger], '\v\$\{[0-9]+(:|!)(.{-})\}', '\2', 'g')
-		endfor
-	endif
-	return l:snippets
 endfunction
 
 function! SimpleSnippets#getSnippetDict(dict, path, filetype)


### PR DESCRIPTION
**Description**
Functions were reordered in call order. Also, trigger lookup now looks for letter only trigger, if no complex trigger found. For example old method looked up for trigger like so:
```c
{for|} // | - cursor
```
First found trigger would be `{for` because it is get with `expand("<cWORD>")` command, so one would be able to use `#if` or `||`, `|}` triggers. If no file with `{for` name found, second lookup happens, and takes output of `expand("<cword>")` command instead, so trigger would be `for`, and if file with name `for` found, it expands. If still no luck, tab character is inserted.

**Breaking change:** no
