### PR TITLE
Fix S-Tab key mappings in documentation

### DIFF
--- a/doc/SimpleSnippets.txt
+++ b/doc/SimpleSnippets.txt
@@ -337,7 +337,7 @@ so:
   `    \"\<Tab>"`
   `inoremap <silent><expr><S-Tab> pumvisible() ? "\<c-p>" :`
   `    \SimpleSnippets#isJumpable() ?`
-  `    \"<Esc>:call SimpleSnippets#jumpToLastPlaceholder()<Cr>" :`
+  `    \"<Esc>:call SimpleSnippets#jumpBackwards()<Cr>" :`
   `    \"\<S-Tab>"`
   `inoremap <silent><expr><Cr> pumvisible() ?`
   `    \SimpleSnippets#isExpandableOrJumpable() ?`
@@ -346,7 +346,7 @@ so:
   `snoremap <silent><expr><Tab> SimpleSnippets#isExpandableOrJumpable() ?`
   `    \"<Esc>:call SimpleSnippets#expandOrJump()<Cr>" : "\<Tab>"`
   `    snoremap <silent><expr><S-Tab> SimpleSnippets#isJumpable() ?`
-  `    \"<Esc>:call SimpleSnippets#jumpToLastPlaceholder()<Cr>" :`
+  `    \"<Esc>:call SimpleSnippets#jumpBackwards()<Cr>" :`
   `    \"\<S-Tab>"`
 
 This is bit tricky, but you can still scroll  through  your  completion  popup


### PR DESCRIPTION
First off, thanks for this nice job.

**Description**
I've just followed the docs, testing its functionality and almost everything worked as expected except when I've tried to use Tab/S-Tab as the same key mapping for completion and snippet jumping/expansion. So, using `jumpBackwards()` instead of `jumpToLastPlaceholder()` worked as expected for me, otherwise after S-Tab it was getting stuck at the same point.   

**Breaking change:** no
