### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# SimpleSnippets.vim
+# SimpleSnippets.vim 
+[![GitHub release](https://img.shields.io/github/release/andreyorst/simplesnippets.vim.svg)](https://github.com/andreyorst/SimpleSnippets.vim/releases)
+[![GitHub Release Date](https://img.shields.io/github/release-date/andreyorst/SimpleSnippets.vim.svg)](https://github.com/andreyorst/SimpleSnippets.vim/releases)
+![Github commits (since latest release)](https://img.shields.io/github/commits-since/andreyorst/Simplesnippets.vim/latest.svg)
+![license](https://img.shields.io/github/license/andreyorst/simplesnippets.vim.svg)
 
 Simple snippets is a simple snippet manager for Vim and NeoVim, based on standard
 editor features, designed to be fast and lightweight. It integrates with Deoplete

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -13,7 +13,7 @@ for dep in ${dependencies[*]}; do
     fi
 done
 
-vim_versions=("nvim" "vim" "vim-7.4.1689")
+vim_versions=("nvim" "vim" "vim-7.4.1689" "vim-7.4.001")
 tests=("lorem" "forward_jumping" "backward_jumping" "for" "cla" "shell" "create_snippet")
 
 cd $(dirname $0)
@@ -45,6 +45,9 @@ if [[ $skip == ${#vim_versions[@]} ]]; then
     echo "No tests vere run at all."
     echo "Please install either vim or neovim and run corresponding tests"
     ((++error))
+else
+    echo "Total test count: $((${#vim_versions[@]} * ${#tests[@]}))"
+    echo "Amount of errors: $error"
 fi
 
 exit $error

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -14,7 +14,7 @@ for dep in ${dependencies[*]}; do
 done
 
 vim_versions=("nvim" "vim" "vim-7.4.1689")
-tests=("lorem" "forward_jumping" "backward_jumping" "for" "cla" "shell")
+tests=("lorem" "forward_jumping" "backward_jumping" "for" "cla" "shell" "create_snippet")
 
 cd $(dirname $0)
 

--- a/testing/tests/create_snippet/reference
+++ b/testing/tests/create_snippet/reference
@@ -1,0 +1,3 @@
+test start
+SimpleSnippets
+test end

--- a/testing/tests/create_snippet/test.sh
+++ b/testing/tests/create_snippet/test.sh
@@ -1,0 +1,23 @@
+test_file=snippet
+test_snippet_file=create
+before_test() {
+    touch $test_file
+    tmux send-keys -t $tmux_session "$vim -n -u ../../testrc $test_file" enter ":redir! > $log_file" enter
+}
+
+test_func() {
+    tmux send-keys -t SimpleSnippetsTest "ggdGitest start" enter "Qq:SimpleSnippetsEdit $test_snippet_file" enter "ggdGi$\\{0:SimpleSnippets\}Qq0f\\xf\\x:wq" enter "i$test_snippet_file" escape "a" tab tab enter "test endQq"
+}
+
+after_test() {
+    tmux send-keys -t $tmux_session ":redir END" enter ":x" enter
+    while [[ $(stat -c %s $test_file) == 0 ]]; do
+        sleep 0.1
+        ((--timeout))
+        if [[ $timeout == 0 ]]; then
+            echo "Timeout reached on deliting $test_snippet_file"
+            break
+        fi
+    done
+    rm ../../snippets/all/$test_snippet_file
+}


### PR DESCRIPTION
**Description**
Fix type error in `getSnippetDict()` function for Vim 7.4.001.
Add highlighting of mirror placeholders by falling back to `matchadd()` if `matchaddpos()` is not available.

**Breaking change:** no
