### PR TITLE
v 0.0.9

### DIFF
--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -119,6 +119,8 @@ function! SimpleSnippets#parseAndInit()
 	let l:ph_amount = SimpleSnippets#countPlaceholders('\v\$\{[0-9]+(:|!)')
 	if l:ph_amount != 0
 		call SimpleSnippets#parseSnippet(l:ph_amount)
+		call SimpleSnippets#initRemainingVisuals()
+		let s:visual_contents = ''
 		if s:snip_line_count != 1
 			let l:indent_lines = s:snip_line_count - 1
 			call cursor(s:snip_start, 1)
@@ -135,6 +137,25 @@ function! SimpleSnippets#parseAndInit()
 		let s:active = 0
 		call cursor(l:cursor_pos[1], l:cursor_pos[2])
 	endif
+endfunction
+
+function! SimpleSnippets#initRemainingVisuals()
+	let l:visual_amount = SimpleSnippets#countPlaceholders('\v\$\{VISUAL\}')
+	let i = 0
+	while i < l:visual_amount
+		call cursor(s:snip_start, 1)
+		call search('\v\$\{VISUAL\}', 'c', s:snip_end)
+		exe "normal! f{%vF$c"
+		let l:result = SimpleSnippets#initVisual()
+		call SimpleSnippets#removeTrailings(l:result)
+		let l:result_line_count = len(substitute(l:result, '[^\n]', '', 'g'))
+		if l:result_line_count > 1
+			silent exec 'normal! V'
+			silent exec 'normal!'. l:result_line_count .'j='
+			let s:snip_end += l:result_line_count
+		endif
+		let i += 1
+	endwhile
 endfunction
 
 function! SimpleSnippets#jump()
@@ -630,6 +651,8 @@ function! SimpleSnippets#initNormal(current)
 		call SimpleSnippets#removeTrailings(l:result)
 		let l:result_line_count = len(substitute(l:result, '[^\n]', '', 'g'))
 		if l:result_line_count > 1
+			silent exec 'normal! V'
+			silent exec 'normal!'. l:result_line_count .'j='
 			let s:snip_end += l:result_line_count
 		endif
 	else
@@ -698,7 +721,6 @@ endfunction
 function! SimpleSnippets#initVisual()
 	if s:visual_contents != ''
 		let l:visual = s:visual_contents
-		let s:visual_contents = ''
 	else
 		let l:visual = ''
 	endif

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -844,11 +844,27 @@ function! SimpleSnippets#edit(trigg)
 		return -1
 	endif
 	if l:trigger != ''
-		call SimpleSnippets#createSplit(l:path, l:trigger, l:filetype)
+		call SimpleSnippets#createSplit(l:path, l:trigger)
+		setf l:filetype
 	else
 		redraw
 		echo "Empty trigger"
 	endif
+endfunction
+
+function! SimpleSnippets#editDescriptions(ft)
+	if a:ft != ''
+		let l:filetype = a:ft
+	else
+		let l:filetype = SimpleSnippets#filetypeWrapper(g:SimpleSnippets_similar_filetypes)
+	endif
+	let l:path = g:SimpleSnippets_search_path . l:filetype
+	let s:snip_edit_buf = 0
+	if !isdirectory(l:path)
+		call mkdir(l:path, "p")
+	endif
+	let l:descriptions = l:filetype.'.snippets.descriptions.txt'
+	call SimpleSnippets#createSplit(l:path, l:descriptions)
 endfunction
 
 function! SimpleSnippets#listSnippets()
@@ -977,14 +993,13 @@ function! SimpleSnippets#execute(command, ...)
 	return l:result
 endfunction
 
-function! SimpleSnippets#createSplit(path, trigger, filetype)
+function! SimpleSnippets#createSplit(path, trigger)
 	if exists("*win_gotoid")
 		if win_gotoid(s:snip_edit_win)
 			try
 				exec "buffer " . s:snip_edit_buf
 			catch
 				exec "edit " . a:path . '/' . a:trigger
-				exec "setf " . a:filetype
 			endtry
 		else
 			vertical new
@@ -992,7 +1007,6 @@ function! SimpleSnippets#createSplit(path, trigger, filetype)
 				exec "buffer " . s:snip_edit_buf
 			catch
 				execute "edit " . a:path . '/' . a:trigger
-				execute "setf " . a:filetype
 				let s:snip_edit_buf = bufnr("")
 			endtry
 			let s:snip_edit_win = win_getid()
@@ -1000,7 +1014,6 @@ function! SimpleSnippets#createSplit(path, trigger, filetype)
 	else
 		vertical new
 		exec "edit " . a:path . '/' . a:trigger
-		exec "setf " . a:filetype
 	endif
 endfunction
 

--- a/autoload/SimpleSnippets.vim
+++ b/autoload/SimpleSnippets.vim
@@ -628,13 +628,19 @@ function! SimpleSnippets#initNormal(current)
 		exe "normal! F{%vF$;c"
 		let l:result = SimpleSnippets#initVisual()
 		call SimpleSnippets#removeTrailings(l:result)
+		let l:result_line_count = len(substitute(l:result, '[^\n]', '', 'g'))
+		if l:result_line_count > 1
+			let s:snip_end += l:result_line_count
+		endif
 	else
 		let l:result = matchstr(getline('.'), l:placeholder)
 		let save_q_mark = getpos("'q")
 		exe "normal! f{mq%i\<Del>\<Esc>g`qF$df:"
 		call setpos("'q", save_q_mark)
 	endif
-	call add(s:jump_stack, l:result)
+	if l:result != ''
+		call add(s:jump_stack, l:result)
+	endif
 	let @" = l:save_quote
 	let l:repeater_count = SimpleSnippets#countPlaceholders('\v\$' . a:current)
 	if l:repeater_count != 0
@@ -694,7 +700,7 @@ function! SimpleSnippets#initVisual()
 		let l:visual = s:visual_contents
 		let s:visual_contents = ''
 	else
-		let l:visual = 'body'
+		let l:visual = ''
 	endif
 	let l:save_s = @s
 	let @s = l:visual

--- a/doc/SimpleSnippets.txt
+++ b/doc/SimpleSnippets.txt
@@ -39,10 +39,11 @@ CONTENTS                                               *SimpleSnippets-contents*
       4.1.1 Snippets descriptions ...... |SimpleSnippets-snippets-descriptions|
       4.1.2 Flash Snippets .................... |SimpleSnippets-flash-snippets|
     4.2 Placeholder Syntax ................ |SimpleSnippets-placeholder-syntax|
-      4.2.1 Normal Placeholders ........... |SimpleSnippets-normal-placeholder|
-      4.2.2 Mirror Placeholders ........... |SimpleSnippets-mirror-placeholder|
-      4.2.3 Command Placeholders ......... |SimpleSnippets-command-placeholder|
+      4.2.1 Normal Placeholder ............ |SimpleSnippets-normal-placeholder|
+      4.2.2 Mirror Placeholder ............ |SimpleSnippets-mirror-placeholder|
+      4.2.3 Command Placeholder .......... |SimpleSnippets-command-placeholder|
       4.2.4 Repeaters ............................... |SimpleSnippets-repeater|
+      4.2.5 Visual Placeholder ............ |SimpleSnippets-visual-placeholder|
     4.3 Snippets Examples ................... |SimpleSnippets-snippet-examples|
  5. Contributing ................................ |SimpleSnippets-contributing|
     5.1 Running tests .......................... |SimpleSnippets-running-tests|
@@ -365,7 +366,7 @@ so:
   `    \"\<Cr>" : "\<Cr>"`
   `snoremap <silent><expr><Tab> SimpleSnippets#isExpandableOrJumpable() ?`
   `    \"<Esc>:call SimpleSnippets#expandOrJump()<Cr>" : "\<Tab>"`
-  `    snoremap <silent><expr><S-Tab> SimpleSnippets#isJumpable() ?`
+  `snoremap <silent><expr><S-Tab> SimpleSnippets#isJumpable() ?`
   `    \"<Esc>:call SimpleSnippets#jumpBackwards()<Cr>" :`
   `    \"\<S-Tab>"`
 
@@ -378,6 +379,8 @@ expand with single key.
 SimpleSnippets also remaps Tab in command mode.  It is done  to  jump  out  of
 mirrored placeholder.  You  can  read  more  about  mirrored  placeholders  at
 |SimpleSnippets-mirror-placeholder|.
+
+There is also a special `xnoremap` for |visual-placeholder|.
 
 
 3.4 Functions                                         *SimpleSnippets-functions*
@@ -645,7 +648,8 @@ should be contained inside snippet file is the snippet's body. No `startsnippet`
 or `endsnippet` entries are necessary.
 
 
-  4.2.1 Normal Placeholders                  *SimpleSnippets-normal-placeholder*
+  4.2.1 Normal Placeholder                   *SimpleSnippets-normal-placeholder*
+                                                            *normal-placeholder*
   ----------------------------------------------------------------------------~
 
   Normal placeholder contains text entry that will be placed in your  expanded
@@ -667,14 +671,16 @@ or `endsnippet` entries are necessary.
   snippet.
 
 
-  4.2.2 Mirror Placeholders                  *SimpleSnippets-mirror-placeholder*
+  4.2.2 Mirror Placeholder                   *SimpleSnippets-mirror-placeholder*
+                                                            *mirror-placeholder*
   ----------------------------------------------------------------------------~
 
-  Mirrored placeholder shares same syntax as normal and  placeholder,  however
-  the implementation of mirrored placeholders in this plugin is very different
-  form other snippet plugins.  What  differs  `normal`  and  `shell`   placeholder
-  from `mirrored` one  is  occurrence of |repeater|s.  If  `repeater` is defined for
-  normal placeholder this placeholder becomes mirrored  one.   For example:
+  Mirrored placeholder shares same syntax as normal and  command  placeholder,
+  however the implementation of mirrored placeholders in this plugin  is  very
+  different  form  other  snippet  plugins.  What  differs  `normal`  and  `shell`
+  placeholder from `mirrored`  one  is  occurrence  of  |repeater|s.   If `repeater`
+  is defined  for |normal-placeholder|  or  |command-placeholder| this placeholder
+  becomes  mirrored  one. For example:
 
     `class ${1:Name} {`
     `public:`
@@ -702,40 +708,16 @@ or `endsnippet` entries are necessary.
   pressed it acts the same way if you would hit <Esc>.  Mirrored  placeholders
   are automatically executing next jump for you.
 
-  However  for  `Command`  placeholder  this  is  not  that   simple.    `Command`
-  placeholders are not jumpable by itself, and therefore are not  mirrored  by
-  default.  Repeaters will repeat their contents across snippet's body, but no
-  prompt will be shown, because no jump were made.   If  you  want  to  mirror
-  `Command` placeholder, consider wrapping it with normal one like so:
 
-    `${2:${1!command}} $2`
-
-  Note,  that  in this  example  `Normal`  placeholder  is  the  one  who  being
-  mirrored, because of the fact that placeholders  are  being  parsed  in  the
-  order  of  their  indexes,  `Command`   placeholder  is  being  parsed  before
-  `Normal` one, and it's body becomes  a  body for normal placeholder, which  is
-  being parsed next  after `Command` one.  Then  repeaters  are  receiving  same
-  body as `Normal` one, and upon jump mirroring is activated.
-
-  4.2.3 Command Placeholders                *SimpleSnippets-command-placeholder*
+  4.2.3 Command Placeholder                 *SimpleSnippets-command-placeholder*
+                                                           *command-placeholder*
   ----------------------------------------------------------------------------~
 
   The implementation of `Command` placeholders relies on Vim  `system()` function.
-  Shell placeholders executes their contents as  a  command  *which  can't  be
-  jumped later, and yank it to your file via `@s` register. If you want  to jump
-  to such placeholder, consider wrapping it inside normal placeholder like so:
-  `${2:${1!uname}`. This  also  makes mirroring easy, because nor you can mirror
-  `$1` if you  don't  want  to  jump to the results, or `$2` if you want  to  make
-  this placeholder jumpable and mirrored.  However, commands that result  more
-  then single line of text are currently broke jumping.  So if  you  want   to
-  yank a file inside snippet's  body,  don't  wrap  `Command`  placeholder  with
-  normal one, because it will break snippet expanding.
-  Example of multiline shell output may be:
-
-    `${0!cat /usr/share/licenses/clang/LICENSE}`
-
-  Placeholder. It can be expanded, but can't be wrapped in `normal` placeholder.
-  For example here is the `uname` snippet:
+  Command placeholder accepts viml facilities like registers, or any command
+  that can be echoed, as well as shell command that provides text output. The
+  syntax is similar to |normal-placeholder| but uses `!` instead of `:`.
+  Consider some examples:
 
   `My current Linux Kernel is:`
   `${0!uname --operating-system --kernel-release}`
@@ -764,10 +746,8 @@ or `endsnippet` entries are necessary.
 
     `"CURRENTLY/EDITED/FILENAME"`
 
-  Viml support is currently experimental.
 
-
-  4.2.4 Repeaters                             *repeater* *SimpleSnippets-repeater*
+  4.2.4 Repeater                              *repeater* *SimpleSnippets-repeater*
   ----------------------------------------------------------------------------~
 
   Repeaters are used to repeat placeholder's body across snippet's  body.   So
@@ -776,17 +756,27 @@ or `endsnippet` entries are necessary.
   on snippet expanding that paceholder's body will  be  substituted  to  every
   occurrence of `$1` inside snippet's body. This also will make that placeholder
   `mirrored` type instead of `normal` type.   Repeaters can be used to any kind of
-  placeholder: `normal`  and  `Command`.    However these two will behave slightly
-  different, as `Command` placeholder  will be  just substituted but not jumped,
-  therefore `Command` `repeater`s will not be jumped either.  You can wrap `Command`
-  placeholder  with  `normal`  placeholder,  and  use  a  `repeater`s  of   `normal`
-  placeholder, to jump and mirror `Command` one
+  placeholder: `normal`  and  `Command`.
 
   Repeaters was added to change core mechanics for mirroring, to make it  more
   easy and maintainable.  This also should add some layer of capability   with
   other  snippet  managers.   Previously  mirroring  was  done  with  separate
   placeholder   type `${1|text}`, and it's  body  must  have  been  repeated  in
   snippet's body. Now this is deprecated.
+
+
+  4.2.5 Visual Placeholder                   *SimpleSnippets-visual-placeholder*
+                                                            *visual-placeholder*
+  ----------------------------------------------------------------------------~
+
+  Visual placeholder is used to place your last visually selected text  inside
+  snippet body. Visual   placeholder is defined with `${VISUAL}` syntax. You can
+  use like so, or nested   inside   |normal-placeholder|: `${0:${VISUAL}}`. To use
+  visual placeholder you need to select text with visual mode, and press  your
+  expand or jump hot key. The text will disappear. Now you can write a trigger
+  and expand snippet.  Your  text  will  be pasted  inside  the snippet's body
+  if  `${VISUAL}` placeholder  is defined.  If  no  text  were  selected  visual
+  placeholder will be removed from jump list.
 
 
 4.3 Snippet Examples                           *SimpleSnippets-snippet-examples*

--- a/plugin/SimpleSnippets.vim
+++ b/plugin/SimpleSnippets.vim
@@ -35,9 +35,11 @@ if s:allow_remap == 1
 	exec "nnoremap <silent><expr>".g:SimpleSnippetsJumpToLastTrigger.' SimpleSnippets#isJumpable() ? "<esc>:call SimpleSnippets#jumpToLastPlaceholder()<Cr>" : "\'.g:SimpleSnippetsJumpToLastTrigger.'"'
 	exec "inoremap <silent><expr>".g:SimpleSnippetsJumpToLastTrigger.' SimpleSnippets#isJumpable() ? "<esc>:call SimpleSnippets#jumpToLastPlaceholder()<Cr>" : "\'.g:SimpleSnippetsJumpToLastTrigger.'"'
 	exec "snoremap <silent><expr>".g:SimpleSnippetsJumpToLastTrigger.' SimpleSnippets#isJumpable() ? "<Esc>:call SimpleSnippets#jumpToLastPlaceholder()<Cr>" : "\'.g:SimpleSnippetsJumpToLastTrigger.'"'
+	exec "snoremap <silent><expr>".g:SimpleSnippetsJumpToLastTrigger.' SimpleSnippets#isJumpable() ? "<Esc>:call SimpleSnippets#jumpToLastPlaceholder()<Cr>" : "\'.g:SimpleSnippetsJumpToLastTrigger.'"'
 endif
+exec "xnoremap <silent>".g:SimpleSnippetsExpandOrJumpTrigger.' <Esc>:call SimpleSnippets#getVisual()<Cr>'
 
-let s:similar_filetypes = [['tex', 'plaintex'], ['bash', 'zsh', 'sh']]
+let s:similar_filetypes = [['tex', 'plaintex'], ['sh', 'zsh', 'bash']]
 
 if exists('g:SimpleSnippets_similar_filetypes')
 	let g:SimpleSnippets_similar_filetypes += s:similar_filetypes

--- a/plugin/SimpleSnippets.vim
+++ b/plugin/SimpleSnippets.vim
@@ -46,5 +46,6 @@ else
 endif
 
 command! -nargs=? SimpleSnippetsEdit call SimpleSnippets#edit("<args>")
+command! -nargs=? SimpleSnippetsEditDescriptions call SimpleSnippets#editDescriptions("<args>")
 command! SimpleSnippetsList call SimpleSnippets#listSnippets()
 

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -25,6 +25,7 @@ tests=(
     "create_snippet"
     "flash"
     "inword_placeholders"
+    "visual"
 )
 
 cd $(dirname $0)

--- a/testing/snippets/all/vis
+++ b/testing/snippets/all/vis
@@ -1,0 +1,1 @@
+Visual contents: ${0:${VISUAL}}

--- a/testing/tests/visual/reference
+++ b/testing/tests/visual/reference
@@ -1,0 +1,3 @@
+test start
+Visual contents: SimpleSnippets
+test end

--- a/testing/tests/visual/test.sh
+++ b/testing/tests/visual/test.sh
@@ -1,0 +1,11 @@
+test_file=visual
+before_test() {
+    touch $test_file
+    tmux send-keys -t $tmux_session "$vim -n -u ../../testrc $test_file" enter ":redir > $log_file" enter
+}
+test_func() {
+    tmux send-keys -t $tmux_session "ggdGitest start" enter "SimpleSnippetsQqV" tab "vis" escape "a" tab tab enter "test endQq"
+}
+after_test() {
+    tmux send-keys -t $tmux_session ":redir END" enter ":x" enter
+}


### PR DESCRIPTION
**Description**
New function:`:SimpleSnippetsEditDescriptions`. Opens split whit descriptions for current filetype. Accepts filetype as optional parameter.
New placeholder: `${VISUAL}`. Adds support of visual placeholder, which allows to select text and yank it to the snippet body automatically.
Docs updated.

**Breaking change:** no
